### PR TITLE
updating square badges to be properly aligned

### DIFF
--- a/binder/logo_badge.svg
+++ b/binder/logo_badge.svg
@@ -3,9 +3,9 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 44.4 44.4" style="enable-background:new 0 0 44.4 44.4;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:none;stroke:#F5A252;stroke-width:5;stroke-miterlimit:10;}
-	.st1{fill:none;stroke:#579ACA;stroke-width:5;stroke-miterlimit:10;}
-	.st2{fill:none;stroke:#E66581;stroke-width:5;stroke-miterlimit:10;}
+	.st0{fill:none;stroke:#F5A252;stroke-width:5.7;stroke-miterlimit:10;}
+	.st1{fill:none;stroke:#579ACA;stroke-width:5.7;stroke-miterlimit:10;}
+	.st2{fill:none;stroke:#E66581;stroke-width:5.7;stroke-miterlimit:10;}
 </style>
 <title>logo</title>
 <g>


### PR DESCRIPTION
This does the following:

1. Adds a "logo_badge" SVG that has slightly thicker lines for small logos (favicon + badge logo)
2. Updates the square badge alignment because it was slightly off (the circles weren't intersecting at the same place)